### PR TITLE
chore/ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/skeet-cli.yml
+++ b/.github/workflows/skeet-cli.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Changes

This PR bumps the `actions/checkout` version from `v3` (using the now end-of-life version of Node [16]) to `v4` (Node 20).

> I noticed all matrix tests for done for Node 18, this change shouldn't conflict with the other actions as it is performed in an isolated manner at the start of the job.